### PR TITLE
FirstChildRedirect::$icon must be marked private

### DIFF
--- a/code/pages/FirstChildRedirect.php
+++ b/code/pages/FirstChildRedirect.php
@@ -2,9 +2,9 @@
 
 class FirstChildRedirect extends Page {
 
-	static $description = "Automatically redirects to the first child of this page";
+	private static $description = "Automatically redirects to the first child of this page";
 
-	static $icon = "mypswd-tweaks/images/icons/first-child-redirect";
+	private static $icon = "mypswd-tweaks/images/icons/first-child-redirect";
 
 	public function getCMSFields() {
     	$fields = parent::getCMSFields();


### PR DESCRIPTION
[User Deprecated] Config static FirstChildRedirect::$icon must be marked as private.
